### PR TITLE
Parse functions

### DIFF
--- a/examples/fun.alice
+++ b/examples/fun.alice
@@ -1,0 +1,36 @@
+fun ping {
+    "ping" println
+}
+
+fun greet -> string {
+    "hello there"
+}
+
+fun pi -> float {
+    0.14 3 + dup swap drop
+}
+
+fun pi_approx -> int {
+    3 0.0@int +
+}
+
+fun drop_three: any, any, any -> string {
+    drop drop drop
+    "dropped three values"
+}
+
+fun gen_greeting: string -> string {
+    "hello, " swap +
+}
+
+fun get_true -> bool {
+    true
+}
+
+"world" gen_greeting() println
+ping()
+greet() println
+"pi: " print pi() println
+"pi approx: " print pi_approx() println
+1 2 3 drop_three() println
+get_true() println

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -50,6 +50,8 @@ pub enum AliceOp {
     Pow, // **
     Mod,
     Eqs,
+    Gt,  // >
+    Lt,  // <
 }
 
 #[derive(Debug)]
@@ -313,7 +315,7 @@ impl CharCollection for AliceSeparator {
 impl CharCollection for AliceOp {
     // on_add_op
     fn all_chars() -> &'static [char] {
-        &['+', '-', '*', '/', '%', '=']
+        &['+', '-', '*', '/', '%', '=', '>', '<']
     }
 }
 
@@ -327,6 +329,8 @@ impl From<char> for AliceOp {
             '/' => AliceOp::Div,
             '%' => AliceOp::Mod,
             '=' => AliceOp::Eqs,
+            '>' => AliceOp::Gt,
+            '<' => AliceOp::Lt,
             _ => panic!("cannot convert {c} into an AliceOp"),
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod runtime;
 mod statement;
 mod type_check;
 mod object;
+mod utils;
 
 use crate::lexer::AliceLexer;
 use crate::parser::AliceParser;
@@ -83,7 +84,7 @@ struct AliceArgs {
 
 fn launch_interactive() {
     let mut stack = crate::runtime::AliceStack::new(64);
-    let mut type_stack = crate::type_check::TypeStack(Vec::new(), HashMap::new());
+    let mut type_stack = crate::type_check::TypeStack::new();
     let mut table = crate::runtime::AliceTable::new(64);
 
     use std::io::Write;
@@ -105,9 +106,9 @@ fn launch_interactive() {
             if let Err(msg) = statements {
                 eprintln!("{}", format!("error parsing input: {msg}"));
                 // have to redo type stack
-                type_stack.0.clear();
+                type_stack.vals.clear();
                 for val in &stack.stack {
-                    type_stack.0.push(crate::type_check::type_bit(val));
+                    type_stack.vals.push(crate::type_check::type_bit(val));
                 }
             } else {
                 let statements = statements.ok().unwrap();

--- a/src/object.rs
+++ b/src/object.rs
@@ -43,12 +43,14 @@ impl AliceFun {
     pub fn type_check(&self) -> Result<(), TypeCheckError> {
         let mut stack = TypeStack::new();
         self.args.push(&mut stack);
-        check_fun(&mut stack, &self.body).map_err(|e| e.prefix("Function signature promise not correct: ".into()))?;
+        check_fun(&mut stack, &self.body).map_err(|e| e.prefix("Function signature doesn't allow for this: ".into()))?;
         if self.return_type == 0 && stack.vals.len() == 0 {
             return Ok(())
         }
-        if stack.vals.len() != 1 {
-            Err(TypeCheckError("functions can only have one return value!".into()))
+        if stack.vals.len() == 0 {
+            Err(TypeCheckError("function should return something but doesn't".into()))
+        } else if stack.vals.len() > 1 {
+            Err(TypeCheckError("function returns more than one value".into()))
         } else if stack.pop().unwrap() != self.return_type {
             Err(TypeCheckError("function has wrong return type!".into()))
         } else {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -244,6 +244,8 @@ impl AliceParser {
             AliceOp::Div => Box::new(DivStatement),
             AliceOp::Pow => Box::new(PowStatement),
             AliceOp::Mod => Box::new(ModStatement),
+            AliceOp::Gt => todo!(),
+            AliceOp::Lt => todo!(),
             AliceOp::Eqs => return Err("unexpected equal sign".into()),
         })
     }

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -521,10 +521,15 @@ impl Statement for PushFromTableStatement {
 
 impl Statement for ExecuteFunStatement {
     fn custom_type_check(&self, stack: &mut TypeStack) -> Result<(), TypeCheckError> {
-        let fun = stack.funs.get(&self.0);
-        if fun.is_some() {
-            let fun = fun.unwrap();
-            stack.vals.push(fun.1);
+        let sig = stack.funs.remove(&self.0);
+        if sig.is_some() {
+            let sig_clone = sig.as_ref().unwrap().clone();
+            stack.funs.insert(self.0.clone(), sig.unwrap());
+            let sig = sig_clone;
+            sig.0.type_check(stack)?;
+            if sig.1 != 0 {
+                stack.vals.push(sig.1);
+            }
             Ok(())
         } else {
             Err(TypeCheckError(format!("function '{}' doesn't exist when this executes!", self.0)))

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -1,4 +1,5 @@
-use crate::runtime::{AliceStack, AliceTable, AliceVal};
+use crate::runtime::*;
+use crate::object::*;
 use crate::type_check::*;
 
 pub trait Statement {
@@ -75,14 +76,24 @@ pub struct ModStatement;
 /// clears the stack
 pub struct ClearStatement;
 
-/// bind a variable
+/// binds a variable
 pub struct LetStatement {
     pub ident: String,
     pub ty: u32,
     pub literal: Option<AliceVal>,
 }
 
+/// copies a variable's value from the table onto the stack
 pub struct PushFromTableStatement(pub String);
+
+/// binds a function
+pub struct FunStatement {
+    pub ident: String,
+    pub fun: AliceFun,
+}
+
+/// executes a function from the table
+pub struct ExecuteFunStatement(pub String);
 
 impl Statement for PushStatement {
     fn out_pattern(&self) -> StackPattern {
@@ -164,8 +175,8 @@ impl Statement for SwapStatement {
     fn custom_type_check(&self, stack: &mut TypeStack) -> Result<(), TypeCheckError> {
         // need to dynamically generate type check patterns
         stack.required_size(2)?;
-        let second = stack.0.remove(stack.0.len() - 2);
-        stack.0.push(second);
+        let second = stack.vals.remove(stack.vals.len() - 2);
+        stack.vals.push(second);
         Ok(())
     }
 
@@ -179,7 +190,7 @@ impl Statement for SwapStatement {
 impl Statement for DupStatement {
     fn custom_type_check(&self, stack: &mut TypeStack) -> Result<(), TypeCheckError> {
         stack.required_size(1)?;
-        stack.0.push(*stack.0.get(stack.0.len() - 1).unwrap()); // unwrapping safe due to previous check
+        stack.vals.push(*stack.vals.get(stack.vals.len() - 1).unwrap()); // unwrapping safe due to previous check
         Ok(())
     }
 
@@ -192,7 +203,7 @@ impl Statement for DupStatement {
 impl Statement for OverStatement {
     fn custom_type_check(&self, stack: &mut TypeStack) -> Result<(), TypeCheckError> {
         stack.required_size(2)?;
-        stack.0.push(*stack.0.get(stack.0.len() - 2).unwrap()); // unwrapping safe due to previoud check
+        stack.vals.push(*stack.vals.get(stack.vals.len() - 2).unwrap()); // unwrapping safe due to previoud check
         Ok(())
     }
 
@@ -205,8 +216,8 @@ impl Statement for OverStatement {
 impl Statement for RotStatement {
     fn custom_type_check(&self, stack: &mut TypeStack) -> Result<(), TypeCheckError> {
         stack.required_size(3)?;
-        let third = stack.0.remove(stack.0.len() - 3);
-        stack.0.push(third);
+        let third = stack.vals.remove(stack.vals.len() - 3);
+        stack.vals.push(third);
         Ok(())
     }
     fn execute(&self, stack: &mut AliceStack, _table: &mut AliceTable) -> Result<(), String> {
@@ -223,7 +234,7 @@ impl Statement for AddStatement {
         stack.required_size(2)?;
         let b = stack.pop().unwrap();
         let a = stack.pop().unwrap();
-        stack.0.push(match (a, b) {
+        stack.vals.push(match (a, b) {
             (INT, INT) => INT,
             (FLOAT, FLOAT) => FLOAT,
             (INT, FLOAT) | (FLOAT, INT) => FLOAT,
@@ -271,7 +282,7 @@ impl Statement for SubStatement {
         stack.required_size(2)?;
         let b = stack.pop().unwrap();
         let a = stack.pop().unwrap();
-        stack.0.push(match (a, b) {
+        stack.vals.push(match (a, b) {
             (INT, INT) => INT,
             (FLOAT, FLOAT) => FLOAT,
             (INT, FLOAT) | (FLOAT, INT) => FLOAT,
@@ -309,7 +320,7 @@ impl Statement for MulStatement {
         stack.required_size(2)?;
         let b = stack.pop().unwrap();
         let a = stack.pop().unwrap();
-        stack.0.push(match (a, b) {
+        stack.vals.push(match (a, b) {
             (INT, INT) => INT,
             (FLOAT, FLOAT) => FLOAT,
             (INT, FLOAT) | (FLOAT, INT) => FLOAT,
@@ -347,7 +358,7 @@ impl Statement for DivStatement {
         stack.required_size(2)?;
         let b = stack.pop().unwrap();
         let a = stack.pop().unwrap();
-        stack.0.push(match (a, b) {
+        stack.vals.push(match (a, b) {
             (INT, INT) => INT,
             (FLOAT, FLOAT) => FLOAT,
             (INT, FLOAT) | (FLOAT, INT) => FLOAT,
@@ -385,7 +396,7 @@ impl Statement for PowStatement {
         stack.required_size(2)?;
         let b = stack.pop().unwrap();
         let a = stack.pop().unwrap();
-        stack.0.push(match (a, b) {
+        stack.vals.push(match (a, b) {
             (INT, INT) => INT,
             (FLOAT, FLOAT) => FLOAT,
             (FLOAT, INT) => FLOAT,
@@ -425,7 +436,7 @@ impl Statement for ModStatement {
         stack.required_size(2)?;
         let b = stack.pop().unwrap();
         let a = stack.pop().unwrap();
-        stack.0.push(match (a, b) {
+        stack.vals.push(match (a, b) {
             (INT, INT) => INT,
             (FLOAT, FLOAT) => FLOAT,
             (INT, FLOAT) | (FLOAT, INT) => FLOAT,
@@ -460,7 +471,7 @@ impl Statement for ModStatement {
 impl Statement for ClearStatement {
     fn custom_type_check(&self, stack: &mut TypeStack) -> Result<(), TypeCheckError> {
         stack.required_size(0)?;
-        stack.0.clear();
+        stack.vals.clear();
         Ok(())
     }
 
@@ -476,7 +487,7 @@ impl Statement for LetStatement {
     }
 
     fn custom_type_check(&self, stack: &mut TypeStack) -> Result<(), TypeCheckError> {
-        stack.1.insert(self.ident.clone(), self.ty);
+        stack.vars.insert(self.ident.clone(), self.ty);
         Ok(())
     }
 
@@ -493,8 +504,8 @@ impl Statement for LetStatement {
 
 impl Statement for PushFromTableStatement {
     fn custom_type_check(&self, stack: &mut TypeStack) -> Result<(), TypeCheckError> {
-        if let Some(ty) = stack.1.get(&self.0) {
-            stack.0.push(*ty);
+        if let Some(ty) = stack.vars.get(&self.0) {
+            stack.vals.push(*ty);
             Ok(())
         } else {
             Err(TypeCheckError(format!("variable binding {} doesn't exist when this executes", self.0)))
@@ -504,6 +515,46 @@ impl Statement for PushFromTableStatement {
     fn execute(&self, stack: &mut AliceStack, table: &mut AliceTable) -> Result<(), String> {
         // unwrapping safe due to type checker
         stack.push(table.get(&self.0).unwrap().clone());
+        Ok(())
+    }
+}
+
+impl Statement for ExecuteFunStatement {
+    fn custom_type_check(&self, stack: &mut TypeStack) -> Result<(), TypeCheckError> {
+        let fun = stack.funs.get(&self.0);
+        if fun.is_some() {
+            let fun = fun.unwrap();
+            stack.vals.push(fun.1);
+            Ok(())
+        } else {
+            Err(TypeCheckError(format!("function '{}' doesn't exist when this executes!", self.0)))
+        }
+    }
+
+    fn execute(&self, stack: &mut AliceStack, table: &mut AliceTable) -> Result<(), String> {
+        let fun = table.take(&self.0);
+        if fun.is_none() {
+            panic!("fix your type checker, dumbass!")
+        }
+        let fun = fun.unwrap();
+        let fun_clone = fun.clone();
+        table.put(self.0.clone(), fun);
+        if let AliceVal::Function(Some(f)) = fun_clone {
+            f.execute(stack, table)
+        } else {
+            panic!("fix your type checker, dumbass")
+        }
+    }
+}
+
+impl Statement for FunStatement {
+    fn custom_type_check(&self, stack: &mut TypeStack) -> Result<(), TypeCheckError> {
+        stack.funs.insert(self.ident.clone(), (self.fun.args.clone(), self.fun.return_type));
+        Ok(())
+    }
+
+    fn execute(&self, stack: &mut AliceStack, table: &mut AliceTable) -> Result<(), String> {
+        table.put(self.ident.clone(), AliceVal::Function(Some(self.fun.clone())));
         Ok(())
     }
 }

--- a/src/type_check.rs
+++ b/src/type_check.rs
@@ -30,9 +30,11 @@ pub fn is_object(bits: &u32) -> bool {
 pub fn check(statements: &Vec<Box<dyn Statement>>) -> Result<(), TypeCheckError> {
     let mut stack = TypeStack::new();
     for s in statements {
+        //println!("type stack before: {:?}", stack);
         s.in_pattern().type_check(&mut stack)?;
         s.custom_type_check(&mut stack)?;
         s.out_pattern().push(&mut stack);
+        //println!("type stack after: {:?}\n", stack);
     }
     if stack.vals.is_empty() {
         Ok(())

--- a/src/type_check.rs
+++ b/src/type_check.rs
@@ -156,3 +156,11 @@ pub fn type_bit(val: &AliceVal) -> u32 {
         AliceVal::Function(_) => panic!("function should not be allowed on stack"),
     }
 }
+
+pub fn type_bit_any_allowed(name: &String) -> Result<u32, String> {
+    if name == "any" {
+        Ok(ANY)
+    } else {
+        Ok(type_bit(&AliceVal::for_type_name(name)?))
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,8 @@
+use crate::statement::Statement;
+
+use std::rc::Rc;
+use std::cell::RefCell;
+
+pub fn box_to_rc(b: Box<dyn Statement>) -> Rc<dyn Statement> {
+    Rc::from(b)
+}


### PR DESCRIPTION
Adds functions of four "types" to the language:

```
# 1. no args, no return type
fun ping {
    "ping" println
}

# 2. no args, with return type
fun name -> string {
    "alice"
}

# 3. args, no return type
fun drop_it_like_its_hot: any {
    drop
}

# 4. args and return type
fun greeting: string -> string {
    "hello, " swap +
}
```

Naturally, they are fully type checked.